### PR TITLE
Fix build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ rm -rf build/ gpufetch
 mkdir build/
 cd build/
 
-if [ "$1" == "debug" ]
+if [ "$1" = "debug" ]
 then
   BUILD_TYPE="Debug"
 else
@@ -29,9 +29,9 @@ fi
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
 
 os=$(uname)
-if [ "$os" == 'Linux' ]; then
+if [ "$os" = 'Linux' ]; then
   make -j$(nproc)
-elif [ "$os" == 'FreeBSD' ]; then
+elif [ "$os" = 'FreeBSD' ]; then
   gmake -j4
 fi
 


### PR DESCRIPTION
Getting errors on Ubuntu 22.04:
```
./build.sh: 10: [: unexpected operator
...
./build.sh: 32: [: Linux==: unexpected operator
./build.sh: 34: [: Linux: unexpected operator
```